### PR TITLE
Add presentation-referenced "commit message" template links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,8 @@ where you can test out `git` commands; not all `git` commands are supported
 ### GitHub Education
 
 - [git cheat sheet](https://education.github.com/git-cheat-sheet-education.pdf)
+
+### Git Commit Message Format Information
+
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+- [cbeams "How to Write a Good Commit Message"](https://cbea.ms/git-commit/)


### PR DESCRIPTION
Submitting some links which I intended originally to include as part of the online course materials.